### PR TITLE
Migrate all methods from conda to apptainer containers

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -3,26 +3,27 @@ WORKFLOWS = [
     "mad_int_featselect",
 ]
 METHODS = [
-    # "scanorama",
+    "scanorama",
     # "scanorama_pca",
-    # "mnn", # pain in the ass, we'll just use the R version fastMNN instead
-    # "fastMNN",
-    # "harmony",
+    # "mnn", # skipped: ancient deps, replaced by fastMNN
+    "fastMNN",
+    "harmony_v1",
+    "harmony_v2",
     # "harmony_pca", # performs the same as normal harmony
-    # "combat",
-    # "desc",
+    "combat",
+    "desc",
     "scvi_single",
-    # "scvi_multi",
-    # "sysvi",    
-    # "scanvi_single",
-    # "scanvi_multi",
-    # "gaushvi",
-    # "gaushanvi", 
-    # "scpoli",
+    "scvi_multi",
+    "sysvi",
+    "scanvi_single",
+    "scanvi_multi",
+    # "gaushvi",  # deferred: custom scvi-tools fork needs investigation
+    # "gaushanvi",  # deferred: custom scvi-tools fork needs investigation
+    "scpoli",
     # "scpoli_pca", # performs quite a bit worse than normal scpoli
-    # "sphering",
-    # "seurat_cca",
-    # "seurat_rpca",
+    "sphering",
+    "seurat_cca",
+    "seurat_rpca",
     # "cpDistiller_B",
     # "cpDistiller_S",
     # "cpDistiller_SBP",

--- a/containers/desc.def
+++ b/containers/desc.def
@@ -1,0 +1,47 @@
+Bootstrap: docker
+From: nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
+
+%environment
+    export LANG=C.UTF-8
+    export LC_ALL=C.UTF-8
+    export NUMBA_CACHE_DIR=/tmp/numba_cache
+    export MPLCONFIGDIR=/tmp/matplotlib
+    export TORCH_HOME=/tmp/torch_home
+
+%post
+    export DEBIAN_FRONTEND=noninteractive
+
+    apt-get update && apt-get install -y \
+        python3.11 \
+        python3.11-dev \
+        python3.11-venv \
+        curl \
+        ca-certificates \
+        git \
+        && rm -rf /var/lib/apt/lists/*
+
+    curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
+    python3.11 -m pip install --no-cache-dir --upgrade pip setuptools wheel
+    ln -sf /usr/bin/python3.11 /usr/local/bin/python
+    ln -sf /usr/bin/python3.11 /usr/local/bin/python3
+
+    # TensorFlow 2.14 with CUDA support
+    python -m pip install --no-cache-dir \
+        "tensorflow==2.14.*"
+
+    # Core scientific stack
+    python -m pip install --no-cache-dir \
+        "numpy<2" \
+        anndata \
+        pandas \
+        scanpy \
+        pyarrow \
+        scipy \
+        scikit-learn \
+        statsmodels \
+        tqdm
+
+    # desc and its specific dependency
+    python -m pip install --no-cache-dir \
+        "python-igraph==0.10.8" \
+        "git+https://github.com/johnarevalo/desc.git"

--- a/containers/harmony_v1.def
+++ b/containers/harmony_v1.def
@@ -1,0 +1,22 @@
+Bootstrap: localimage
+From: containers/base.sif
+
+%environment
+    # JAX is needed only for scib-metrics benchmarking inside optimize_harmony.
+    # CPU is sufficient and avoids GPU contention.
+    export JAX_PLATFORMS=cpu
+
+%post
+    export DEBIAN_FRONTEND=noninteractive
+
+    # annoy (scanorama dep in lightweight) needs g++ — not needed here,
+    # but keep build-essential for any C extensions in dependencies
+    apt-get update && apt-get install -y build-essential && rm -rf /var/lib/apt/lists/*
+
+    # Pin harmonypy to the last pre-Harmony2 release (v1 algorithm).
+    # v0.0.10 uses the original (E+1)/(O+1) soft-assignment formula.
+    # v0.1.0+ switched to the Harmony2 E/(O+E) formula (not toggleable).
+    python -m pip install --no-cache-dir \
+        "harmonypy==0.0.10" \
+        optuna \
+        "jax[cpu]"

--- a/containers/lightweight.def
+++ b/containers/lightweight.def
@@ -1,0 +1,21 @@
+Bootstrap: localimage
+From: containers/base.sif
+
+%environment
+    # JAX is needed only for scib-metrics benchmarking inside optimize_harmony.
+    # CPU is sufficient and avoids GPU contention.
+    export JAX_PLATFORMS=cpu
+
+%post
+    export DEBIAN_FRONTEND=noninteractive
+
+    # annoy (scanorama dep) needs g++ to compile C++ extensions
+    apt-get update && apt-get install -y build-essential && rm -rf /var/lib/apt/lists/*
+
+    python -m pip install --no-cache-dir \
+        harmonypy \
+        scanorama \
+        bbknn \
+        leidenalg \
+        optuna \
+        "jax[cpu]"

--- a/containers/r.def
+++ b/containers/r.def
@@ -1,0 +1,33 @@
+Bootstrap: docker
+From: rocker/r-ver:4.4.0
+
+%environment
+    export LANG=C.UTF-8
+    export LC_ALL=C.UTF-8
+
+%post
+    export DEBIAN_FRONTEND=noninteractive
+
+    # System libraries needed by arrow, igraph, and other R packages
+    apt-get update && apt-get install -y \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        libxml2-dev \
+        libfontconfig1-dev \
+        libharfbuzz-dev \
+        libfribidi-dev \
+        libglpk-dev \
+        cmake \
+        && rm -rf /var/lib/apt/lists/*
+
+    # Use Posit Package Manager for pre-compiled Linux binaries (much faster)
+    PPM="https://packagemanager.posit.co/cran/__linux__/jammy/latest"
+
+    # CRAN packages shared by fastMNN and seurat
+    R -e "install.packages(c('arrow', 'dplyr', 'optparse', 'remotes', 'Matrix', 'matrixStats'), repos='${PPM}')"
+
+    # Bioconductor packages for fastMNN
+    R -e "install.packages('BiocManager', repos='${PPM}'); BiocManager::install(c('batchelor', 'SingleCellExperiment'), ask=FALSE)"
+
+    # Seurat
+    R -e "install.packages(c('Seurat', 'SeuratObject'), repos='${PPM}')"

--- a/containers/scpoli.def
+++ b/containers/scpoli.def
@@ -1,0 +1,61 @@
+Bootstrap: docker
+From: nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
+
+%environment
+    export LANG=C.UTF-8
+    export LC_ALL=C.UTF-8
+    export NUMBA_CACHE_DIR=/tmp/numba_cache
+    export MPLCONFIGDIR=/tmp/matplotlib
+    export XLA_PYTHON_CLIENT_PREALLOCATE=false
+    export TORCH_HOME=/tmp/torch_home
+    export JAX_PLATFORMS=cpu
+    # scarches checks for this; without it, sklearn import fails
+    export SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
+
+%post
+    export DEBIAN_FRONTEND=noninteractive
+
+    # scpoli requires Python 3.9 (scarches + scvi-tools 1.1.6 compatibility)
+    apt-get update && apt-get install -y \
+        software-properties-common \
+        curl \
+        ca-certificates \
+        && add-apt-repository -y ppa:deadsnakes/ppa \
+        && apt-get update \
+        && apt-get install -y \
+        python3.9 \
+        python3.9-dev \
+        python3.9-venv \
+        python3.9-distutils \
+        && rm -rf /var/lib/apt/lists/*
+
+    curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9
+    python3.9 -m pip install --no-cache-dir --upgrade pip setuptools wheel
+    ln -sf /usr/bin/python3.9 /usr/local/bin/python
+    ln -sf /usr/bin/python3.9 /usr/local/bin/python3
+
+    # PyTorch 2.0 with CUDA 12.1
+    python -m pip install --no-cache-dir \
+        torch==2.0.0 \
+        --index-url https://download.pytorch.org/whl/cu118
+
+    # Core scientific stack (pinned for scvi-tools 1.1.6 compat)
+    python -m pip install --no-cache-dir \
+        "numpy<2" \
+        anndata \
+        pandas \
+        scanpy \
+        pyarrow \
+        scipy \
+        scikit-learn \
+        statsmodels \
+        tqdm
+
+    # scvi-tools 1.1.6 + scarches + optimization deps
+    python -m pip install --no-cache-dir \
+        "scvi-tools==1.1.6.post2" \
+        "numpyro==0.15.3" \
+        "scarches==0.6.1" \
+        scib-metrics \
+        optuna \
+        "jax[cpu]"

--- a/pixi.toml
+++ b/pixi.toml
@@ -30,6 +30,11 @@ seaborn = "*"
 build-base = "[ containers/base.sif -nt containers/base.def ] && echo 'base.sif is up to date' || apptainer build --force containers/base.sif containers/base.def"
 build-scvi = { cmd = "[ containers/scvi.sif -nt containers/scvi.def ] && [ containers/scvi.sif -nt containers/base.def ] && echo 'scvi.sif is up to date' || apptainer build --force containers/scvi.sif containers/scvi.def", depends-on = ["build-base"] }
 build-scibmetrics = { cmd = "[ containers/scibmetrics.sif -nt containers/scibmetrics.def ] && [ containers/scibmetrics.sif -nt containers/base.def ] && echo 'scibmetrics.sif is up to date' || apptainer build --force containers/scibmetrics.sif containers/scibmetrics.def", depends-on = ["build-base"] }
-build-containers = { depends-on = ["build-scvi", "build-scibmetrics"] }
+build-lightweight = { cmd = "[ containers/lightweight.sif -nt containers/lightweight.def ] && [ containers/lightweight.sif -nt containers/base.def ] && echo 'lightweight.sif is up to date' || apptainer build --force containers/lightweight.sif containers/lightweight.def", depends-on = ["build-base"] }
+build-scpoli = "[ containers/scpoli.sif -nt containers/scpoli.def ] && echo 'scpoli.sif is up to date' || apptainer build --force containers/scpoli.sif containers/scpoli.def"
+build-desc = "[ containers/desc.sif -nt containers/desc.def ] && echo 'desc.sif is up to date' || apptainer build --force containers/desc.sif containers/desc.def"
+build-r = "[ containers/r.sif -nt containers/r.def ] && echo 'r.sif is up to date' || apptainer build --force containers/r.sif containers/r.def"
+build-harmony-v1 = { cmd = "[ containers/harmony_v1.sif -nt containers/harmony_v1.def ] && [ containers/harmony_v1.sif -nt containers/base.def ] && echo 'harmony_v1.sif is up to date' || apptainer build --force containers/harmony_v1.sif containers/harmony_v1.def", depends-on = ["build-base"] }
+build-containers = { depends-on = ["build-scvi", "build-scibmetrics", "build-lightweight", "build-harmony-v1", "build-scpoli", "build-desc", "build-r"] }
 pipeline = "PATH=$(dirname $(which python)):$PATH snakemake -c20 --configfile inputs/conf/scenario_7.json --sdm conda apptainer --conda-prefix './env_store/' --apptainer-args=--nv --resources nvidia_gpu=2"
 unlock = "PATH=$(dirname $(which python)):$PATH snakemake -c20 --configfile inputs/conf/scenario_7.json --sdm conda apptainer --conda-prefix './env_store/' --apptainer-args=--nv --resources nvidia_gpu=2 --unlock"

--- a/rules/bbknn.smk
+++ b/rules/bbknn.smk
@@ -10,8 +10,8 @@ rule bbknn_clustering:
         "outputs/{prefix}/logs/{criteria}_{pipeline}_bbknn_clustering.log",
     params:
         batch_key=config["batch_key"],
-    conda:
-        "../envs/bbknn.yaml"
+    container:
+        "containers/lightweight.sif"
     shell:
         """
         export PYTHONPATH=$(dirname $(pwd)):$(pwd) && \

--- a/rules/correct.smk
+++ b/rules/correct.smk
@@ -14,13 +14,13 @@ rule methods_combat:
     input:
         data="outputs/{scenario}/" + config["preproc"] + ".parquet",
         script="scripts/correct_with_combat.py",
-        parameter_path="outputs/{scenario}/optimization/optuna_harmony.csv"
+        parameter_path="outputs/{scenario}/optimization/optuna_harmony_v2.csv"
     output:
         path="outputs/{scenario}/" + config["preproc"] + "_combat.parquet"
     log:
         "outputs/{scenario}/logs/" + config["preproc"] + "_correct_combat.log"
-    conda:
-        "../envs/harmony.yaml"  # we only need scanpy so this will do
+    container:
+        "containers/base.sif"  # combat only needs scanpy, which is in base
     params:
         batch_key=config["batch_key"] if isinstance(config["batch_key"], str) else config["batch_key"][0],
     resources:
@@ -44,8 +44,8 @@ rule methods_sphering:
         path="outputs/{scenario}/" + config["preproc"] + "_sphering.parquet"
     log:
         "outputs/{scenario}/logs/" + config["preproc"] + "_correct_sphering.log"
-    conda:
-        "../envs/sphering.yaml"
+    container:
+        "containers/base.sif"
     params:
         method="ZCA-cor",
         column_norm="Metadata_JCP2022",
@@ -64,17 +64,46 @@ rule methods_sphering:
             &> '{log}'
         """
 
-rule methods_harmony:
+rule methods_harmony_v1:
     input:
         data="outputs/{scenario}/" + config["preproc"] + ".parquet",
         script="scripts/correct_with_harmony.py",
-        parameter_path="outputs/{scenario}/optimization/optuna_harmony.csv"
+        parameter_path="outputs/{scenario}/optimization/optuna_harmony_v1.csv"
     output:
-        path="outputs/{scenario}/" + config["preproc"] + "_harmony.parquet"
+        path="outputs/{scenario}/" + config["preproc"] + "_harmony_v1.parquet"
     log:
-        "outputs/{scenario}/logs/" + config["preproc"] + "_correct_harmony.log"
-    conda:
-        "../envs/harmony.yaml"
+        "outputs/{scenario}/logs/" + config["preproc"] + "_correct_harmony_v1.log"
+    container:
+        "containers/harmony_v1.sif"
+    params:
+        batch_key=config["batch_key"] if isinstance(config["batch_key"], str) else config["batch_key"][0],
+        smoketest="--smoketest" if config["smoketest"] else "",
+    resources:
+        nvidia_gpu=1
+    shell:
+        """
+        export PYTHONPATH=$(dirname $(pwd)):$(pwd) && \
+        python '{input.script}' \
+            --mode 'harmony' \
+            --input_data '{input.data}' \
+            --batch_key '{params.batch_key}' \
+            --parameter_path '{input.parameter_path}' \
+            --output_path '{output.path}' \
+            {params.smoketest} \
+            &> '{log}'
+        """
+
+rule methods_harmony_v2:
+    input:
+        data="outputs/{scenario}/" + config["preproc"] + ".parquet",
+        script="scripts/correct_with_harmony.py",
+        parameter_path="outputs/{scenario}/optimization/optuna_harmony_v2.csv"
+    output:
+        path="outputs/{scenario}/" + config["preproc"] + "_harmony_v2.parquet"
+    log:
+        "outputs/{scenario}/logs/" + config["preproc"] + "_correct_harmony_v2.log"
+    container:
+        "containers/lightweight.sif"
     params:
         batch_key=config["batch_key"] if isinstance(config["batch_key"], str) else config["batch_key"][0],
         smoketest="--smoketest" if config["smoketest"] else "",
@@ -101,8 +130,8 @@ rule methods_harmony_pca:
         path="outputs/{scenario}/" + config["preproc"] + "_harmony_pca.parquet"
     log:
         "outputs/{scenario}/logs/" + config["preproc"] + "_correct_harmony_pca.log"
-    conda:
-        "../envs/harmony.yaml"
+    container:
+        "containers/lightweight.sif"
     params:
         batch_key=config["batch_key"] if isinstance(config["batch_key"], str) else config["batch_key"][0],
         smoketest="--smoketest" if config["smoketest"] else "",
@@ -128,8 +157,8 @@ rule methods_scanorama:
         path="outputs/{scenario}/" + config["preproc"] + "_scanorama.parquet"
     log:
         "outputs/{scenario}/logs/" + config["preproc"] + "_correct_scanorama.log"
-    conda:
-        "../envs/scanorama.yaml"
+    container:
+        "containers/lightweight.sif"
     params:
         method="scanorama",
         batch_key=config["batch_key"] if isinstance(config["batch_key"], str) else config["batch_key"][0],
@@ -154,8 +183,8 @@ rule methods_scanorama_pca:
         path="outputs/{scenario}/" + config["preproc"] + "_scanorama_pca.parquet"
     log:
         "outputs/{scenario}/logs/" + config["preproc"] + "_correct_scanorama_pca.log"
-    conda:
-        "../envs/scanorama.yaml"
+    container:
+        "containers/lightweight.sif"
     params:
         method="scanorama_pca",
         batch_key=config["batch_key"] if isinstance(config["batch_key"], str) else config["batch_key"][0],
@@ -204,8 +233,8 @@ rule methods_desc:
         path="outputs/{scenario}/" + config["preproc"] + "_desc.parquet"
     log:
         "outputs/{scenario}/logs/" + config["preproc"] + "_correct_desc.log"
-    conda:
-        "../envs/desc.yaml"
+    container:
+        "containers/desc.sif"
     params:
         batch_key=config["batch_key"] if isinstance(config["batch_key"], str) else config["batch_key"][0],
         smoketest="--smoketest" if config["smoketest"] else "",
@@ -424,6 +453,7 @@ rule methods_sysvi:
         nvidia_gpu=1
     shell:
         """
+        export JAX_PLATFORMS=cuda && \
         export PYTHONPATH=$(dirname $(pwd)):$(pwd) && \
         python '{input.script}' \
             --input_data '{input.data}' \
@@ -444,8 +474,8 @@ rule methods_scpoli:
         path="outputs/{scenario}/" + config["preproc"] + "_scpoli.parquet"
     log:
         "outputs/{scenario}/logs/" + config["preproc"] + "_correct_scpoli.log"
-    conda:
-        "../envs/scpoli.yaml"
+    container:
+        "containers/scpoli.sif"
     params:
         batch_key=','.join(config["batch_key"]),
         label_key=config["label_key"],
@@ -474,8 +504,8 @@ rule methods_scpoli_pca:
         path="outputs/{scenario}/" + config["preproc"] + "_scpoli_pca.parquet"
     log:
         "outputs/{scenario}/logs/" + config["preproc"] + "_correct_scpoli_pca.log"
-    conda:
-        "../envs/scpoli.yaml"
+    container:
+        "containers/scpoli.sif"
     params:
         batch_key=','.join(config["batch_key"]),
         label_key=config["label_key"],
@@ -503,8 +533,8 @@ rule methods_fastMNN:
         path="outputs/{scenario}/" + config["preproc"] + "_fastMNN.parquet"
     log:
         "outputs/{scenario}/logs/" + config["preproc"] + "_correct_fastmnn.log"
-    conda:
-        "../envs/fastmnn.yaml"
+    container:
+        "containers/r.sif"
     params:
         batch_key=config["batch_key"] if isinstance(config["batch_key"], str) else config["batch_key"][0],
     resources:
@@ -527,8 +557,8 @@ rule methods_seurat_cca:
         path="outputs/{scenario}/" + config["preproc"] + "_seurat_cca.parquet"
     log:
         "outputs/{scenario}/logs/" + config["preproc"] + "_correct_seurat_cca.log"
-    conda:
-        "../envs/seurat.yaml"
+    container:
+        "containers/r.sif"
     params:
         batch_key=config["batch_key"] if isinstance(config["batch_key"], str) else config["batch_key"][0],
         method="cca",
@@ -553,8 +583,8 @@ rule methods_seurat_rpca:
         path="outputs/{scenario}/" + config["preproc"] + "_seurat_rpca.parquet"
     log:
         "outputs/{scenario}/logs/" + config["preproc"] + "_correct_seurat_rpca.log"
-    conda:
-        "../envs/seurat.yaml"
+    container:
+        "containers/r.sif"
     params:
         batch_key=config["batch_key"] if isinstance(config["batch_key"], str) else config["batch_key"][0],
         method="rpca",

--- a/rules/tune.smk
+++ b/rules/tune.smk
@@ -7,8 +7,8 @@ rule optimize_scpoli:
         path="outputs/{scenario}/optimization/optuna_scpoli.csv"
     log:
         "outputs/{scenario}/logs/" + config["preproc"] + "_optimize_scpoli.log"
-    conda:
-        "../envs/scpoli.yaml"
+    container:
+        "containers/scpoli.sif"
     params:
         batch_key=','.join(config["batch_key"]),
         label_key=config["label_key"],
@@ -178,6 +178,7 @@ rule optimize_sysvi:
         nvidia_gpu=1
     shell:
         """
+        export JAX_PLATFORMS=cuda && \
         export PYTHONPATH=$(dirname $(pwd)):$(pwd) && \
         python '{input.script}' \
             --input_data '{input.data}' \
@@ -189,16 +190,46 @@ rule optimize_sysvi:
             &> '{log}'
         """
 
-rule optimize_harmony:
+rule optimize_harmony_v1:
     input:
         data="outputs/{scenario}/" + config["preproc"] + ".parquet",
         script="scripts/optimise_harmony.py"
     output:
-        path="outputs/{scenario}/optimization/optuna_harmony.csv"
+        path="outputs/{scenario}/optimization/optuna_harmony_v1.csv"
     log:
-        "outputs/{scenario}/logs/" + config["preproc"] + "_optimize_harmony.log"
-    conda:
-        "../envs/harmony.yaml"
+        "outputs/{scenario}/logs/" + config["preproc"] + "_optimize_harmony_v1.log"
+    container:
+        "containers/harmony_v1.sif"
+    params:
+        batch_key=config["batch_key"] if isinstance(config["batch_key"], str) else config["batch_key"][0],
+        label_key=config["label_key"],
+        trials=config["optuna_trials"],
+        smoketest="--smoketest" if config["smoketest"] else "",
+    resources:
+        nvidia_gpu=1
+    shell:
+        """
+        export PYTHONPATH=$(dirname $(pwd)):$(pwd) && \
+        python '{input.script}' \
+            --input_data '{input.data}' \
+            --batch_key '{params.batch_key}' \
+            --label_key '{params.label_key}' \
+            --n_trials '{params.trials}' \
+            --output_path '{output.path}' \
+            {params.smoketest} \
+            &> '{log}'
+        """
+
+rule optimize_harmony_v2:
+    input:
+        data="outputs/{scenario}/" + config["preproc"] + ".parquet",
+        script="scripts/optimise_harmony.py"
+    output:
+        path="outputs/{scenario}/optimization/optuna_harmony_v2.csv"
+    log:
+        "outputs/{scenario}/logs/" + config["preproc"] + "_optimize_harmony_v2.log"
+    container:
+        "containers/lightweight.sif"
     params:
         batch_key=config["batch_key"] if isinstance(config["batch_key"], str) else config["batch_key"][0],
         label_key=config["label_key"],


### PR DESCRIPTION
## Summary

- **Migrate all active Snakemake rules from conda envs to apptainer containers** for faster startup on Lustre (squashfs eliminates thousands of metadata round-trips per import)
- **Add 5 new container definitions**: `lightweight` (harmony/scanorama/bbknn), `desc` (TF 2.14), `scpoli` (Python 3.9), `r` (fastMNN/Seurat), `harmony_v1` (pre-Harmony2 algorithm)
- **Split harmony into `harmony_v1` and `harmony_v2`** for explicit comparison of the original vs second-generation algorithm (harmonypy 0.0.10 vs 0.2.0)
- **Re-enable methods** previously commented out: scanorama, fastMNN, harmony, combat, desc, scpoli
- **Fix sysvi**: override `JAX_PLATFORMS=cuda` in shell commands (needs GPU JAX, but scvi.sif defaults to cpu)
- **Fix r.def**: add `libglpk-dev` to resolve batchelor install failure

### Container map

| Container | Methods | Notes |
|---|---|---|
| `base.sif` | combat, sphering | Core scientific stack only |
| `scvi.sif` | scvi, scanvi, sysvi | PyTorch + JAX + scvi-tools |
| `lightweight.sif` | harmony_v2, scanorama, bbknn | harmonypy 0.2.0 (Harmony2 algorithm) |
| `harmony_v1.sif` | harmony_v1 | harmonypy 0.0.10 (original algorithm) |
| `scibmetrics.sif` | metrics | JAX CPU only |
| `desc.sif` | desc | TensorFlow 2.14 + CUDA |
| `scpoli.sif` | scpoli | Python 3.9 (scarches compat) |
| `r.sif` | fastMNN, seurat_cca, seurat_rpca | R 4.4 + batchelor + Seurat |

## Test plan

- [x] `snakemake --lint` passes
- [x] `snakemake -n` dry run resolves all 28 jobs
- [x] All 8 containers build successfully
- [x] R container: `batchelor`, `Seurat`, `arrow` load
- [x] harmony_v1 container: `harmonypy==0.0.10` confirmed
- [x] lightweight container: `harmonypy==0.2.0` confirmed
- [ ] Full pipeline end-to-end run (`pixi run pipeline`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)