### PR TITLE
Improve Seurat CCA/RPCA robustness for cross-microscope scenarios

### DIFF
--- a/scripts/correct_with_seurat.R
+++ b/scripts/correct_with_seurat.R
@@ -32,9 +32,10 @@ k_weight_val <- opt$k_weight
 
 if (!is.null(opt$parameter_path)) {
   params_df <- read.csv(opt$parameter_path)
-  params_df <- params_df[order(-params_df$total), ]
-  best <- params_df[1, ]
-  if (best$state != "COMPLETE") stop("Optimization did not complete successfully")
+  complete_df <- params_df[params_df$state == "COMPLETE", ]
+  if (nrow(complete_df) == 0) stop("No COMPLETE trials in HPO — fix upstream before correction")
+  complete_df <- complete_df[order(-complete_df$total), ]
+  best <- complete_df[1, ]
   dims_val <- as.integer(best$params_dims)
   k_anchor_val <- as.integer(best$params_k_anchor)
   k_weight_val <- as.integer(best$params_k_weight)
@@ -72,19 +73,53 @@ obj <- ScaleData(obj, verbose = FALSE)
 obj <- RunPCA(obj, npcs = dims_val, verbose = FALSE)
 
 # Seurat v5 integration via IntegrateLayers
-obj <- IntegrateLayers(
-  object = obj,
-  method = if (opt$method == "cca") CCAIntegration else RPCAIntegration,
-  orig.reduction = "pca",
-  new.reduction = "integrated",
-  dims = 1:dims_val,
-  k.anchor = k_anchor_val,
-  k.weight = k_weight_val,
-  verbose = FALSE
-)
+# Retry with progressively lower k.weight on failure or NaN output
+integration_method <- if (opt$method == "cca") CCAIntegration else RPCAIntegration
+k_weight_try <- k_weight_val
+integrated_obj <- NULL
+
+while (k_weight_try >= 3) {
+  result <- tryCatch(
+    IntegrateLayers(
+      object = obj,
+      method = integration_method,
+      orig.reduction = "pca",
+      new.reduction = "integrated",
+      dims = 1:dims_val,
+      k.anchor = k_anchor_val,
+      k.weight = k_weight_try,
+      verbose = FALSE
+    ),
+    error = function(e) {
+      cat(sprintf("IntegrateLayers failed with k.weight=%d: %s\n", k_weight_try, conditionMessage(e)))
+      NULL
+    }
+  )
+
+  if (!is.null(result)) {
+    mat <- Embeddings(result, "integrated")
+    if (all(is.finite(mat))) {
+      integrated_obj <- result
+      break
+    } else {
+      n_bad <- sum(!is.finite(mat))
+      cat(sprintf("k.weight=%d produced %d non-finite values, retrying lower\n", k_weight_try, n_bad))
+    }
+  }
+
+  k_weight_try <- k_weight_try %/% 2
+}
+
+if (is.null(integrated_obj)) {
+  stop("IntegrateLayers failed at all k.weight values down to 3")
+}
+
+if (k_weight_try != k_weight_val) {
+  cat(sprintf("NOTE: Used effective k.weight=%d (requested %d)\n", k_weight_try, k_weight_val))
+}
 
 # Extract integrated embedding
-integrated_embed <- Embeddings(obj, "integrated")
+integrated_embed <- Embeddings(integrated_obj, "integrated")
 corrected_df <- as.data.frame(integrated_embed)
 colnames(corrected_df) <- paste0("seurat_", seq_len(ncol(corrected_df)))
 

--- a/scripts/optimise_seurat.py
+++ b/scripts/optimise_seurat.py
@@ -31,10 +31,26 @@ def _build_cache(input_data, batch_key, cache_path):
     return True
 
 
-def objective(trial, input_data, batch_key, label_key, method, cache_path):
+def _get_min_batch_size(input_data, batch_key):
+    """Read the input parquet via R (arrow) and return the smallest batch size."""
+    r_code = (
+        f'suppressPackageStartupMessages(library(arrow)); '
+        f'df <- read_parquet("{input_data}", col_select = "{batch_key}"); '
+        f'cat(min(table(df[["{batch_key}"]])))'
+    )
+    result = subprocess.run(
+        ["Rscript", "-e", r_code], capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        logger.warning("Could not read batch sizes: %s", result.stderr[-300:])
+        return None
+    return int(result.stdout.strip())
+
+
+def objective(trial, input_data, batch_key, label_key, method, cache_path, k_weight_max):
     dims = trial.suggest_int("dims", 5, 50)
     k_anchor = trial.suggest_int("k_anchor", 3, 30)
-    k_weight = trial.suggest_int("k_weight", 50, 200)
+    k_weight = trial.suggest_int("k_weight", 5, k_weight_max)
 
     cmd = [
         "Rscript", "scripts/run_seurat_trial.R",
@@ -57,12 +73,20 @@ def objective(trial, input_data, batch_key, label_key, method, cache_path):
         logger.warning("Trial failed: %s", result.stderr[-500:] if result.stderr else "no stderr")
         raise optuna.TrialPruned(f"R trial failed (exit {result.returncode})")
 
-    for line in reversed(result.stdout.strip().split("\n")):
+    stdout = result.stdout.strip()
+
+    # Record effective k_weight if R had to retry with a lower value
+    for line in stdout.split("\n"):
+        if line.startswith("EFFECTIVE_K_WEIGHT:"):
+            trial.set_user_attr("effective_k_weight", int(line.split(":")[1]))
+            break
+
+    for line in reversed(stdout.split("\n")):
         if line.startswith("RESULT:"):
             batch_score, bio_score = map(float, line[7:].split(","))
             return batch_score, bio_score
 
-    logger.warning("No RESULT line in R output: %s", result.stdout[-500:])
+    logger.warning("No RESULT line in R output: %s", stdout[-500:])
     raise optuna.TrialPruned("No RESULT line in R output")
 
 
@@ -77,12 +101,30 @@ def optimize_seurat(input_path, batch_key, label_key, method, n_trials, output_p
         logger.warning("Cache build failed, falling back to per-trial parquet loading")
         cache_path = None
 
+    # Adapt k_weight upper bound to the smallest batch.
+    # Seurat's FindWeights requires k_weight <= anchor count per pair.
+    # Anchor count scales with batch size and cross-batch similarity.
+    # With heterogeneous sources (different microscopes), anchor counts can be
+    # much lower than batch size, so we use a conservative fraction.
+    min_batch = _get_min_batch_size(input_path, batch_key)
+    if min_batch is not None:
+        k_weight_max = min(200, max(20, min_batch // 10))
+        logger.info("min_batch_size=%d → k_weight range [5, %d]", min_batch, k_weight_max)
+    else:
+        k_weight_max = 200
+        logger.info("Could not determine batch sizes, using k_weight range [5, %d]", k_weight_max)
+
     study = optuna.create_study(
         directions=["maximize", "maximize"],
         sampler=optuna.samplers.TPESampler(seed=42),
     )
+
+    # Seed with a conservative first trial: high k_anchor (more anchors),
+    # low k_weight (safe), and Arevalo default dims.
+    study.enqueue_trial({"dims": 30, "k_anchor": 30, "k_weight": min(k_weight_max, 10)})
+
     study.optimize(
-        lambda trial: objective(trial, input_path, batch_key, label_key, method, cache_path),
+        lambda trial: objective(trial, input_path, batch_key, label_key, method, cache_path, k_weight_max),
         n_trials=n_trials,
         catch=(Exception,),
     )

--- a/scripts/run_seurat_trial.R
+++ b/scripts/run_seurat_trial.R
@@ -82,20 +82,58 @@ if (!is.null(opt$cached_rds) && file.exists(opt$cached_rds)) {
 }
 
 integration_method <- if (opt$method == "cca") CCAIntegration else RPCAIntegration
-obj <- IntegrateLayers(
-  object = obj,
-  method = integration_method,
-  orig.reduction = "pca",
-  new.reduction = "integrated",
-  dims = 1:opt$dims,
-  k.anchor = opt$k_anchor,
-  k.weight = opt$k_weight,
-  verbose = FALSE
-)
 
-corrected_mat <- Embeddings(obj, "integrated")
-batch_labels <- obj@meta.data[[opt$batch_key]]
-bio_labels <- obj@meta.data[[opt$label_key]]
+# Retry integration with progressively lower k.weight if it fails or produces NaN.
+# This handles cross-microscope scenarios where anchor counts vary across source pairs.
+k_weight_try <- opt$k_weight
+integrated_obj <- NULL
+
+while (k_weight_try >= 3) {
+  result <- tryCatch(
+    IntegrateLayers(
+      object = obj,
+      method = integration_method,
+      orig.reduction = "pca",
+      new.reduction = "integrated",
+      dims = 1:opt$dims,
+      k.anchor = opt$k_anchor,
+      k.weight = k_weight_try,
+      verbose = FALSE
+    ),
+    error = function(e) {
+      cat(sprintf("IntegrateLayers failed with k.weight=%d: %s\n",
+                  k_weight_try, conditionMessage(e)), file = stderr())
+      NULL
+    }
+  )
+
+  if (!is.null(result)) {
+    mat <- Embeddings(result, "integrated")
+    if (all(is.finite(mat))) {
+      integrated_obj <- result
+      break
+    } else {
+      n_bad <- sum(!is.finite(mat))
+      cat(sprintf("k.weight=%d produced %d non-finite values, retrying lower\n",
+                  k_weight_try, n_bad), file = stderr())
+    }
+  }
+
+  k_weight_try <- k_weight_try %/% 2
+}
+
+if (is.null(integrated_obj)) {
+  cat("All k.weight attempts failed\n", file = stderr())
+  quit(status = 1)
+}
+
+if (k_weight_try != opt$k_weight) {
+  cat(sprintf("EFFECTIVE_K_WEIGHT:%d\n", k_weight_try))
+}
+
+corrected_mat <- Embeddings(integrated_obj, "integrated")
+batch_labels <- integrated_obj@meta.data[[opt$batch_key]]
+bio_labels <- integrated_obj@meta.data[[opt$label_key]]
 
 batch_score <- compute_pcr_batch(corrected_mat, batch_labels)
 bio_score <- compute_pcr_bio(corrected_mat, bio_labels)


### PR DESCRIPTION
## Summary
- **Adaptive k_weight bounds**: Reads min batch size to set k_weight upper bound, lowers minimum from 50→5, seeds conservative first trial to prevent Optuna sampler crash
- **k_weight retry loop**: tryCatch around IntegrateLayers with halving k_weight on failure/NaN (down to 3), in both HPO trial runner and correction script
- **COMPLETE trial filtering**: Filters for COMPLETE trials before selecting best params, preventing selection of PRUNED/FAIL rows

## Context
Scenario 4 (5 sources, 3 microscope types) caused 30/30 Seurat HPO trials to fail: cross-microscope source pairs produce too few MNN anchors for the default k_weight range (50-200). The TPE sampler then crashed on all-None values, and the correction script selected a PRUNED row.

These fixes won't make CCA/RPCA work on fundamentally incompatible cross-microscope data, but they make failures clean and maximize the chance of success on borderline cases.