### PR TITLE
Update task tracking: S3 relaunch and stale HPO lesson

### DIFF
--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -100,6 +100,12 @@
 - Correct approach: `rm -f .snakemake/locks/0.input.lock .snakemake/locks/0.output.lock` then `mkdir -p .snakemake/locks` before relaunching.
 - Alternative: use `snakemake --unlock` but this sometimes stalls if the DAG is complex.
 
+### Stale HPO CSVs with all-PRUNED/FAIL trials block corrections (2026-03-29)
+- When R HPO trials are killed (exit -9, OOM), Optuna marks them PRUNED. The CSV file exists and Snakemake considers HPO "done", but the correction script rejects it ("Optimization did not complete successfully") because no trial has state=COMPLETE.
+- Snakemake won't re-run HPO because the output file exists. Must manually delete the stale CSV to trigger re-run.
+- Affected scenario_3: fastMNN and seurat_rpca HPO had all 30 trials PRUNED/FAIL from MIG OOM. Deleted CSVs, need 2nd `pixi run scenario-3` after current run.
+- Future-proofing idea: the correction scripts could check for at least one COMPLETE trial before reading HPO CSVs, and exit with a clear message (they already do this).
+
 ### Wave 1 vs Wave 2 compound replication is fundamentally different (2026-03-29)
 - **Wave 1** (7 partners): Each partner exchanges with 4 of 6 others. Per-source replication is median 1 well/compound. Cross-source replication comes from exchange — 74.5% of compounds in 5+ sources. Breadth-first design (82K compounds).
 - **Wave 2** (3 partners): Each partner exchanges with both others. 84.8% of compounds in ALL 3 sources. Per-source replication is 2-4 wells. Combined median 7 reps. Depth-first design (36K compounds).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -35,7 +35,7 @@ Run all 15 methods × 5 original scenarios × 30 HPO trials.
 |----------|---------|-------------|-----------|--------|
 | scenario_1 | source_6 | TARGET2 | Metadata_Batch | DONE (2026-03-28). All 15 methods, metrics, plots. PR #29 merged. |
 | scenario_2 | 3 sources | TARGET2 | Metadata_Source | DONE (2026-03-28). scpoli re-HPO'd with updated epochs. PR #30 merged. |
-| scenario_3 | 3 sources | TARGET2+COMPOUND | Metadata_Source | OOM-killed on gpusrv43 (MIG 20GB). ~60% done. HPO complete: harmony v1/v2, scvi_single, seurat_rpca, fastMNN. Corrections done: combat, sphering, harmony v1/v2, scvi_single. Failed: scANVI (broadcast_labels 555GiB), seurat_cca/rpca/fastMNN corrections (MIG OOM). In-progress: scanorama 18/30, scvi_multi 1/30. Needs full A100 relaunch. scANVI auto-skipped via Snakefile fix. Branch: feature/scenario-3-5-results |
+| scenario_3 | 3 sources | TARGET2+COMPOUND | Metadata_Source | RELAUNCHED (2026-03-29 18:42) on full A100 80GB. HPO running: scvi_multi 3/30, scanorama 1/30, seurat_cca 0/30. fastMNN+seurat_rpca HPO stale CSVs deleted — need 2nd relaunch after current run. scANVI auto-skipped. Completed from prior run: preprocessing, combat, sphering, harmony v1/v2, scvi_single. Branch: feature/docs-and-scenario-research (pushed to myfork). |
 | scenario_4 | 5 sources | TARGET2 | Metadata_Source | Not started |
 | scenario_5 | 5 sources | TARGET2+COMPOUND | Metadata_Source | Not started |
 
@@ -48,7 +48,8 @@ Run all 15 methods × 5 original scenarios × 30 HPO trials.
 - [x] Commit scenario_2 results (PR #30, merged)
 - [x] Launch scenario_3: `pixi run scenario-3` — launched 2026-03-28 23:40 on gpusrv43, PID 590014
 - [x] ~~Monitor scenario_3~~ — OOM-killed 2026-03-29 18:05 on MIG 20GB partition. ~60% done. Locks cleared, scANVI auto-skip added to Snakefile.
-- [ ] Relaunch scenario_3 on a **full A100 node** (not MIG). `pixi run scenario-3` with `--rerun-incomplete`. Completed steps won't re-run.
+- [x] Relaunch scenario_3 on full A100 80GB (2026-03-29 18:42). scvi_multi/scanorama/seurat_cca HPO running. Stale fastMNN+seurat_rpca HPO CSVs deleted.
+- [ ] After current S3 run completes: relaunch `pixi run scenario-3` again to pick up fastMNN HPO + seurat_rpca HPO (CSVs were deleted, Snakemake needs a 2nd pass)
 - [x] Fix scANVI broadcast_labels OOM for COMPOUND-plate scenarios — added auto-skip in Snakefile when `plate_types` includes COMPOUND
 - [x] Create wave2 config (`inputs/conf/scenario_wave2.json`) — sources 5,9,11, T2+COMPOUND, batch=Metadata_Source
 - [ ] Launch scenario_4: `pixi run scenario-4`


### PR DESCRIPTION
## Summary
- Update scenario 3 status: relaunched on full A100 80GB after MIG OOM kill
- Add lesson learned: stale HPO CSVs with all-PRUNED/FAIL trials block correction scripts
- Track that fastMNN + seurat_rpca HPO need a 2nd pipeline pass (stale CSVs deleted)